### PR TITLE
Specify root directory for public assets

### DIFF
--- a/src/components/Card.module.scss
+++ b/src/components/Card.module.scss
@@ -94,7 +94,7 @@
 
 .los {
   .color {
-    background-image: url("los_bg.png");
+    background-image: url("/los_bg.png");
     view-transition-name: los-card;
 
     svg {

--- a/src/pages/Los.module.scss
+++ b/src/pages/Los.module.scss
@@ -7,7 +7,7 @@
 }
 
 .header {
-  background-image: url("los_bg.png");
+  background-image: url("/los_bg.png");
   background-size: cover;
   background-position: 50% 25%;
 }


### PR DESCRIPTION
Assets in the `/public` directory aren’t properly mapped in SCSS if they aren’t prefixed with `/`.